### PR TITLE
Enable Mesh to SFU upgrade functionality

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -77,7 +77,7 @@ app.post('/api/room', basicAuth(), async (req, res) => {
         'content-type': 'application/json',
         'x-vcs-token': process.env.VCS_API_KEY
       },
-      body: JSON.stringify({ name: req.body.name, conferenceType: req.body.conferenceType })
+      body: JSON.stringify({ name: req.body.name, conferenceType: req.body.conferenceType, autoUpgradeParticipantCount: req.body.autoUpgradeParticipantCount })
     });
     if (!result.ok) {
       throw new Error(`${result.status} ${result.statusText}`);

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -515,7 +515,7 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "optional": true
     },
     "less": {
@@ -776,8 +776,8 @@
       "optional": true
     },
     "vcs-realtime-sdk": {
-      "version": "https://sdk.virtualcareservices.net/dist/vcs-realtime-sdk-0.8.4.tgz",
-      "integrity": "sha512-gazj008Y+YITPBLExtFSgSA14rBGTCo0vHvW8QpMfFVPoYLp7pkiCCQ7C1StJV4T1fYEzfkVNmNrGl4U3OyGrw==",
+      "version": "https://sdk.virtualcareservices.net/dist/vcs-realtime-sdk-0.9.2.tgz",
+      "integrity": "sha512-FzDQ+FESFRfC5SSDlmvQUyDxIUZbxoAJhXP9hQTLZaem3ANbAFL1VVZjNqxek/oWHleQBcbOXSzlyAyTUxDjbg==",
       "requires": {
         "shellcheck": "1.1.0"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,7 @@
     "@mdi/js": "6.6.96",
     "countries-list": "2.6.1",
     "random-words": "1.1.2",
-    "vcs-realtime-sdk": "https://sdk.virtualcareservices.net/dist/vcs-realtime-sdk-0.8.4.tgz",
+    "vcs-realtime-sdk": "https://sdk.virtualcareservices.net/dist/vcs-realtime-sdk-0.9.2.tgz",
     "vue": "3.2.33",
     "vue-router": "4.0.14",
     "vuex": "4.0.2"


### PR DESCRIPTION
-   Missing the backend handling of upgradeOnParticipantCount parameter
-   Use vcs-realtime-sdk that supports Mesh to SFU upgrade